### PR TITLE
Input , ColorInput common components

### DIFF
--- a/src/components/color-input/ColorInput.stories.tsx
+++ b/src/components/color-input/ColorInput.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { ColorInput, type ColorInputProps } from './ColorInput';
+
+const meta = {
+  title: 'Components/ColorInput',
+  component: ColorInput,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: 'color',
+      table: { type: { summary: 'string' } },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    onChange: {
+      action: 'changed',
+      table: { disable: true },
+    },
+  },
+} satisfies Meta<ColorInputProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: '#41c74d',
+    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: '#41c74d',
+    disabled: true,
+  },
+};

--- a/src/components/color-input/ColorInput.tsx
+++ b/src/components/color-input/ColorInput.tsx
@@ -1,0 +1,54 @@
+import { forwardRef } from 'react';
+
+import { cx } from '@/utils';
+
+import { Input, type InputProps } from '../input';
+
+export interface ColorInputProps extends Omit<InputProps, 'type'> {}
+
+export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
+  ({ value, onChange, disabled, className, ...rest }, ref) => (
+    <div className={cx('group relative', className)}>
+      <div
+        className={cx(
+          'relative flex items-center rounded-lg border border-gray-700',
+          'shadow-[inset_0_1px_1px_rgba(0,0,0,0.075)]',
+          'focus-within:border-[#66afe9]',
+          'focus-within:shadow-[inset_0_1px_1px_rgba(0,0,0,0.075),0_0_8px_rgba(102,175,233,0.6)]',
+        )}
+      >
+        <Input
+          {...rest}
+          ref={ref}
+          type="text"
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          placeholder="#rrggbb"
+          className="pr-12"
+        />
+
+        <div
+          className={cx(
+            'absolute inset-y-0 right-0 flex items-center justify-center',
+            'border-l border-gray-700 px-2',
+            'group-focus-within:border-l-[#66afe9]',
+            'group-focus-within:shadow-[inset_0_1px_1px_rgba(0,0,0,0.075),0_0_8px_rgba(102,175,233,0.6)]',
+          )}
+        >
+          <input
+            type="color"
+            value={value as string}
+            onChange={onChange}
+            disabled={disabled}
+            className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
+          />
+          <span
+            style={{ backgroundColor: value as string }}
+            className="pointer-events-none size-6 rounded-full border border-gray-600"
+          />
+        </div>
+      </div>
+    </div>
+  ),
+);

--- a/src/components/color-input/index.ts
+++ b/src/components/color-input/index.ts
@@ -1,0 +1,1 @@
+export * from './ColorInput';

--- a/src/components/input/Input.stories.tsx
+++ b/src/components/input/Input.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { Input, type InputProps } from './Input';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: {
+      control: 'text',
+      table: { type: { summary: 'string' } },
+    },
+    state: {
+      control: { type: 'radio' },
+      options: ['default', 'error'],
+      table: {
+        type: { summary: 'default | error' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'number', 'email', 'password'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'text' },
+      },
+    },
+    value: {
+      control: 'text',
+      table: { type: { summary: 'string | number' } },
+    },
+    onChange: {
+      action: 'changed',
+      table: { disable: true },
+    },
+  },
+} satisfies Meta<InputProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Type something…',
+    state: 'default',
+    disabled: false,
+    type: 'text',
+    value: '',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    placeholder: 'Invalid value',
+    state: 'error',
+    disabled: false,
+    type: 'text',
+    value: '',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Cannot edit',
+    state: 'default',
+    disabled: true,
+    type: 'text',
+    value: 'Read only',
+  },
+};
+
+export const NumberInput: Story = {
+  args: {
+    placeholder: 'Enter a number',
+    state: 'default',
+    disabled: false,
+    type: 'number',
+    value: 42,
+  },
+};

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,0 +1,49 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import React, { forwardRef } from 'react';
+
+import { cx } from '@/utils';
+
+const inputVariants = cva(
+  [
+    'bg-transparent border border-gray-700 rounded-lg px-4 py-2 w-full outline-none',
+    'text-gray-50 placeholder-gray-500 transition-colors',
+    'shadow-[inset_0_1px_1px_rgba(0,0,0,0.075)]',
+    'hover:border-gray-600 focus:ring-0',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+  ].join(' '),
+  {
+    variants: {
+      state: {
+        default: [
+          'focus:border-[#66afe9]',
+          'focus:shadow-[inset_0_1px_1px_rgba(0,0,0,0.075),0_0_8px_rgba(102,175,233,0.6)]',
+        ].join(' '),
+        error: [
+          'border-red-600 focus:border-red-600 hover:border-red-500',
+          'focus:shadow-[inset_0_1px_1px_rgba(0,0,0,0.075),0_0_8px_rgba(220,38,38,0.6)]',
+        ].join(' '),
+      },
+    },
+    defaultVariants: {
+      state: 'default',
+    },
+  },
+);
+
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
+    VariantProps<typeof inputVariants> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, state, disabled, type = 'text', ...props }, ref) => (
+    <input
+      ref={ref}
+      type={type}
+      disabled={disabled}
+      className={cx(inputVariants({ state }), className)}
+      {...props}
+    />
+  ),
+);
+
+Input.displayName = 'Input';

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -1,0 +1,1 @@
+export * from './Input';


### PR DESCRIPTION
Input , ColorInput common components https://linear.app/globobeet/issue/PED-7/input-colorinput-common-components

Currently, ColorInput is implemented without any third-party libraries — it uses the native <input type="color">
Let me know if any additional customization is needed